### PR TITLE
Path output updates for readability & regex targeting.

### DIFF
--- a/internal/render/svg.ts
+++ b/internal/render/svg.ts
@@ -31,7 +31,7 @@ export const renderPath = (shape: Shape): string => {
         const next = getNext();
         const currControl = expandHandle(curr, curr.handleOut);
         const nextControl = expandHandle(next, next.handleIn);
-        path += `C${currControl.x},${currControl.y},${nextControl.x},${nextControl.y},${next.x},${next.y}`;
+        path += ` C${currControl.x},${currControl.y} ${nextControl.x},${nextControl.y} ${next.x},${next.y}`;
     });
     return path;
 };


### PR DESCRIPTION
Update path output to be a bit more readable and targetable via regexes. This could be handy for debugging the path or needing to modify it after generation (For example for making it a responsive clip-path).