### PR TITLE
Adding ES Modules to the final build

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -132,17 +132,17 @@
             <nav>
                 <a
                     href="https://github.com/g-harel/blobs"
-                    style="transform: rotate(1deg) translateY(3px);"
+                    style="transform: rotate(1deg) translateY(3px)"
                     >GITHUB</a
                 >
                 <a
                     href="https://npmjs.com/package/blobs"
-                    style="transform: rotate(-2deg) translateY(-1px);"
+                    style="transform: rotate(-2deg) translateY(-1px)"
                     >NPM</a
                 >
                 <a
                     href="mailto:gabrielj.harel@gmail.com"
-                    style="transform: rotate(4deg) translateY(1px);"
+                    style="transform: rotate(4deg) translateY(1px)"
                     >CONTACT</a
                 >
             </nav>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "g-harel",
   "license": "MIT",
   "main": "index.js",
+  "module": "index.module.js",
   "types": "index.d.ts",
   "scripts": {
     "prepack": "npm run build",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,21 +29,23 @@ const bundles = [
     },
 ];
 
-export default bundles.map((bundle) => ({
-    input: bundle.entry,
-    output: {
-        file: bundle.output + "/index.js",
-        format: "umd",
-        name: bundle.name,
-        sourcemap: true,
-    },
-    plugins: [
-        typescript({cacheRoot: "./node_modules/.cache/rpt2"}),
-        uglify(),
-        copy({
-            hook: "writeBundle",
-            targets: [{src: bundle.types, dest: bundle.output, rename: "index.d.ts"}],
-            verbose: true,
-        }),
-    ],
-}));
+export default ["es", "umd"].flatMap((format) =>
+    bundles.map((bundle) => ({
+        input: bundle.entry,
+        output: {
+            file: bundle.output + `/index${format == "es" ? ".module" : ""}.js`,
+            format: format,
+            name: bundle.name,
+            sourcemap: true,
+        },
+        plugins: [
+            typescript({cacheRoot: "./node_modules/.cache/rpt2"}),
+            uglify(),
+            copy({
+                hook: "writeBundle",
+                targets: [{src: bundle.types, dest: bundle.output, rename: "index.d.ts"}],
+                verbose: true,
+            }),
+        ],
+    })),
+);


### PR DESCRIPTION
Currently, if you have a ES bundler (Vite, Snowpack) you cannot use this library, as it uses an outdated module system (UMD).
I added the support for ES modules. It just builds 4 additional files for both versions of the lib.
Most bundlers (Vite including) will use `index.module.js` by default, but it's a convention to also add a `module` key in the `package.json`.